### PR TITLE
CI: update Codecov to v3

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -42,6 +42,6 @@ jobs:
       run: |
         pytest --cov=./
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true


### PR DESCRIPTION
As of February 1, 2022, v1 has been fully sunset and no longer functions. See https://github.com/codecov/codecov-action#readme

This is likely the cause of the error we see in windows-latest jobs:

    {'detail': ErrorDetail(string='Missing "owner" argument. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}